### PR TITLE
dep: change urigo:angular to official Meteor 1.2 angular

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -13,7 +13,7 @@
 
   genUtils = require('../util.js');
 
-  meteorToAdd = ['add', 'urigo:angular', 'angularui:angular-ui-router'];
+  meteorToAdd = ['add', 'angular', 'angularui:angular-ui-router'];
 
   meteorToRemove = ['remove'];
 

--- a/generators/init/index.js
+++ b/generators/init/index.js
@@ -13,7 +13,7 @@
 
   genUtils = require('../util.js');
 
-  meteorToAdd = ['urigo:angular', 'angularui:angular-ui-router'];
+  meteorToAdd = ['angular', 'angularui:angular-ui-router'];
 
   meteorToRemove = [];
 

--- a/src/app/index.coffee
+++ b/src/app/index.coffee
@@ -6,7 +6,7 @@ _i = require('underscore.inflection')
 genUtils = require('../util.js')
 meteorToAdd = [
   'add'
-  'urigo:angular'
+  'angular'
   'angularui:angular-ui-router'
 ]
 meteorToRemove = [

--- a/src/init/index.coffee
+++ b/src/init/index.coffee
@@ -5,7 +5,7 @@ _ = require('underscore.string')
 _i = require('underscore.inflection')
 genUtils = require('../util.js')
 meteorToAdd = [
-  'urigo:angular'
+  'angular'
   'angularui:angular-ui-router'
 ]
 meteorToRemove = []


### PR DESCRIPTION
With the recent Meteor 1.2 update, `urigo:angular` has been merged into a official Meteor `angular` package.

Same docs, same author - just merged into a Meteor-supported official package.
