### PR TITLE
Update index.coffee - fix issue #24

### DIFF
--- a/src/app/index.coffee
+++ b/src/app/index.coffee
@@ -211,6 +211,8 @@ module.exports = yeoman.generators.Base.extend(
     return
   removeMeteorPackages: ->
     cb = @async()
+    
+    meteorToRemove.push 'ecmascript', 'blaze-html-templates'
     if @filters.auth
       meteorToRemove.push 'insecure'
     if @filters.pagination


### PR DESCRIPTION
fixes

```
error: conflict: two packages included in the app (angular-templates and templating) are both trying to     handle *.html

error: conflict: two packages included in the app (pbastowski:angular-babel and ecmascript) are both trying to handle *.js
```

by removing meteor packages 'ecmascript' and 'blaze-html-templates'
