### PR TITLE
Update index.coffee

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -13,9 +13,9 @@
 
   genUtils = require('../util.js');
 
-  meteorToAdd = ['add', 'angular', 'ejson', 'angularui:angular-ui-router', 'urigo:angular-blaze-template'];
+  meteorToAdd = ['add', 'angular-with-blaze', 'ejson', 'angularui:angular-ui-router', 'urigo:angular-blaze-template'];
 
-  meteorToRemove = ['remove'];
+  meteorToRemove = ['remove', 'ecmascript'];
 
   angularModules = ['angular-meteor', 'ui.router'];
 

--- a/src/app/index.coffee
+++ b/src/app/index.coffee
@@ -6,13 +6,14 @@ _i = require('underscore.inflection')
 genUtils = require('../util.js')
 meteorToAdd = [
   'add'
-  'angular'
+  'angular-with-blaze'
   'ejson'
   'angularui:angular-ui-router'
   'urigo:angular-blaze-template'
 ]
 meteorToRemove = [
   'remove'
+  'ecmascript'
 ]
 angularModules = [
   'angular-meteor'


### PR DESCRIPTION
fixes

```
error: conflict: two packages included in the app (angular-templates and templating) are both trying to     handle *.html

error: conflict: two packages included in the app (pbastowski:angular-babel and ecmascript) are both trying to handle *.js
```

by removing meteor packages 'ecmascript' and using package 'angular-with-blaze' instead of 'angular'
