### PR TITLE
Solve error with material route view

### DIFF
--- a/generators/route/templates/material/client/complex/compname-singular-detail.view(html).ng.html
+++ b/generators/route/templates/material/client/complex/compname-singular-detail.view(html).ng.html
@@ -10,7 +10,7 @@
       <div layout="row">
         <input class="md-button" type="submit" value="Save">
         <md-button ng-click="reset()">Reset</md-button>
-        <md-button ng-click="/<%= compname %>">Cancel</md-button>
+        <md-button ng-href="/<%= compname %>">Cancel</md-button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
The material route detail view has an error with the cancel" button and the button does not work.
The error looks like this.

`Error: [$parse:syntax] Syntax Error: Token '/' not a primary expression at column 1 of the expression [/dndsandbox] starting at [/dndsandbox].`

this tiny fix solves the problem
